### PR TITLE
Update translations key

### DIFF
--- a/legacy/js/translations.js
+++ b/legacy/js/translations.js
@@ -71,7 +71,7 @@ export const translations = {
             customerPotential: 'Kundenpotenzial',
             currentSituation: 'Aktuelle Situation',
             goals: 'Ziele & Bedürfnisse',
-            arguments: 'Verkaufsargumente',
+            keyArguments: 'Verkaufsargumente',
             strategy: 'Strategie',
             nextSteps: 'Nächste Schritte'
         },
@@ -169,7 +169,7 @@ export const translations = {
             customerPotential: 'Customer Potential',
             currentSituation: 'Current Situation',
             goals: 'Goals & Needs',
-            arguments: 'Sales Arguments',
+            keyArguments: 'Sales Arguments',
             strategy: 'Strategy',
             nextSteps: 'Next Steps'
         },


### PR DESCRIPTION
## Summary
- rename `arguments` to `keyArguments` in JS translation file

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0f37964483249ac89eb7bbe37660