### PR TITLE
fix: ESLint-Fehler in M4 Frontend Code behoben

### DIFF
--- a/frontend/src/features/opportunity/components/KanbanBoard.tsx
+++ b/frontend/src/features/opportunity/components/KanbanBoard.tsx
@@ -8,13 +8,10 @@ import {
   Badge,
   Card,
   CardContent,
-  Stack,
-  Chip,
   Avatar,
   LinearProgress,
   ToggleButton,
   ToggleButtonGroup,
-  Grid,
   Alert,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';

--- a/frontend/src/features/opportunity/components/KanbanBoardDndKit.tsx
+++ b/frontend/src/features/opportunity/components/KanbanBoardDndKit.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import {
   DndContext,
-  closestCorners,
   KeyboardSensor,
   PointerSensor,
   useSensor,
@@ -12,7 +11,6 @@ import {
 } from '@dnd-kit/core';
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import {
-  arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
@@ -25,7 +23,6 @@ import {
   Card,
   CardContent,
   Stack,
-  Chip,
   Avatar,
   LinearProgress,
   IconButton,
@@ -210,7 +207,6 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
   showActions = false
 }) => {
   const theme = useTheme();
-  const [isHovered, setIsHovered] = React.useState(false);
 
   const getProbabilityColor = (probability?: number) => {
     if (!probability) return theme.palette.grey[400];
@@ -710,7 +706,7 @@ export const KanbanBoardDndKit: React.FC = () => {
   const activeOpportunity = activeId ? opportunities.find(o => o.id === activeId) : null;
 
   // Custom collision detection that prioritizes quick drop zones
-  const customCollisionDetection = (args: any) => {
+  const customCollisionDetection = (args: Parameters<typeof rectIntersection>[0]) => {
     // Use rect intersection for better drop zone detection
     return rectIntersection(args);
   };

--- a/frontend/src/features/opportunity/components/OpportunityCard.tsx
+++ b/frontend/src/features/opportunity/components/OpportunityCard.tsx
@@ -4,10 +4,8 @@ import {
   CardContent,
   Typography,
   Box,
-  Chip,
   Avatar,
   LinearProgress,
-  IconButton,
   Tooltip,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -116,7 +114,7 @@ export const OpportunityCard: React.FC<OpportunityCardProps> = ({
         // Drag & Drop hat Priorität über onClick
         pointerEvents: 'auto',
       }}
-      onClick={(e) => {
+      onClick={() => {
         // Nur onClick wenn nicht gedraggt wird
         if (!isDragging) {
           onClick?.(opportunity);

--- a/frontend/src/features/opportunity/components/OpportunityPipeline.tsx
+++ b/frontend/src/features/opportunity/components/OpportunityPipeline.tsx
@@ -11,7 +11,7 @@ import { DndContext, DragOverlay, closestCorners } from '@dnd-kit/core';
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 
 // Import unserer neuen Komponenten
-import { PipelineStage, OpportunityStage, STAGE_CONFIGS } from './PipelineStage';
+import { PipelineStage, OpportunityStage } from './PipelineStage';
 import { OpportunityCard } from './OpportunityCard';
 import type { Opportunity } from './OpportunityCard';
 
@@ -55,21 +55,7 @@ const mockOpportunities: Opportunity[] = [
   }
 ];
 
-// Mock Pipeline Stats
-const mockPipelineData = {
-  totalOpportunities: mockOpportunities.length,
-  totalValue: mockOpportunities.reduce((sum, opp) => sum + (opp.value || 0), 0),
-  conversionRate: 0.35,
-  stageDistribution: Object.values(OpportunityStage).reduce((acc, stage) => {
-    const stageOpps = mockOpportunities.filter(opp => opp.stage === stage);
-    acc[stage] = {
-      count: stageOpps.length,
-      value: stageOpps.reduce((sum, opp) => sum + (opp.value || 0), 0),
-      opportunities: stageOpps,
-    };
-    return acc;
-  }, {} as Record<OpportunityStage, { count: number, value: number, opportunities: Opportunity[] }>)
-};
+// Mock Pipeline Stats - wird später durch echte API ersetzt
 
 /**
  * M4 Opportunity Pipeline - Kanban Board für Verkaufschancen

--- a/frontend/src/pages/OpportunityPipelinePage.tsx
+++ b/frontend/src/pages/OpportunityPipelinePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import { MainLayoutV2 } from '../components/layout/MainLayoutV2';
 import { KanbanBoardDndKit } from '../features/opportunity/components/KanbanBoardDndKit';
 


### PR DESCRIPTION
## Zusammenfassung
Behebt alle 14 ESLint-Fehler die verhindert haben, dass die CI grün wird.

## Problem
Die CI war rot wegen ESLint-Fehlern im direkt gepushten M4 Frontend Code:
- 14 Errors verhinderten erfolgreichen Build
- Unbenutzte Imports und Variablen
- TypeScript `any` Type Verwendung

## Lösung
- ✅ Entfernt unbenutzte Imports: `Stack`, `Chip`, `Grid`, `IconButton`, `Typography`
- ✅ Entfernt unbenutzte Variablen: `isHovered`, `mockPipelineData`
- ✅ Ersetzt `any` Type durch korrektes TypeScript Typing
- ✅ Entfernt unbenutzte Event-Parameter

## Testing
```bash
cd frontend
npm run lint
# Ergebnis: 0 errors, 19 warnings ✅
```

## Wichtige Hinweise
- Keine funktionalen Änderungen
- Nur Code-Cleanup für CI Compliance
- Backup-Branch erstellt: `backup/main-before-eslint-20250725-043326`

## Related
- Fixes TODO-93
- Ermöglicht grüne CI für M4 Frontend Code
- Voraussetzung für weitere M4 Entwicklung

🤖 Erstellt mit [Claude Code](https://claude.ai/code)