### PR TITLE
🚨 HOTFIX: Flyway V243 Checksum Fix (FP-277) - PRODUCTION BLOCKER

### DIFF
--- a/backend/src/main/resources/db/migration/V243__update_guc_keys.sql
+++ b/backend/src/main/resources/db/migration/V243__update_guc_keys.sql
@@ -69,4 +69,11 @@ END $$;
 
 -- 3. Function check_rls_context already created in V242
 -- with the correct new GUC keys. No update needed here.
--- GRANT already handled in V242, no duplicate needed.
+
+-- Grant execute to application role (if it exists)
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'freshplan') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION check_rls_context() TO freshplan';
+    END IF;
+END $$;

--- a/backend/src/main/resources/db/migration/V244__cleanup_redundant_grant.sql
+++ b/backend/src/main/resources/db/migration/V244__cleanup_redundant_grant.sql
@@ -1,0 +1,34 @@
+-- V244: Cleanup redundanter GRANT (idempotent)
+--
+-- Kontext: In V242 wurde check_rls_context() erstellt und GRANT vergeben.
+-- In V243 wurde versehentlich der gleiche GRANT nochmals eingefügt.
+-- Diese Migration dokumentiert das und ist idempotent (no-op).
+--
+-- WICHTIG: V243 darf NICHT geändert werden, da sie bereits deployed ist!
+-- Der redundante GRANT in V243 ist harmlos (PostgreSQL ignoriert doppelte GRANTs).
+
+-- Dokumentation für Audit-Trail
+DO $$
+BEGIN
+    -- Dieser Block dokumentiert, dass wir uns des redundanten GRANTs bewusst sind
+    -- Der GRANT in V242 ist ausreichend, der in V243 ist redundant aber harmlos
+
+    -- Prüfe ob die Funktion existiert und die Rechte korrekt sind
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.routines
+        WHERE routine_name = 'check_rls_context'
+    ) THEN
+        -- Rechte sind bereits durch V242 und V243 vergeben
+        -- Nichts zu tun - idempotent
+        RAISE NOTICE 'check_rls_context() permissions already correctly set by V242/V243';
+    ELSE
+        -- Dies sollte nie passieren, da V242 die Funktion erstellt
+        RAISE WARNING 'check_rls_context() function not found - check migrations V242/V243';
+    END IF;
+END $$;
+
+-- Zusätzliche Dokumentation als Kommentar für zukünftige Entwickler:
+-- Der redundante GRANT in V243 wurde beibehalten um Flyway-Checksum-Fehler
+-- in bereits migrierten Umgebungen zu vermeiden.
+-- Best Practice: Deployed migrations niemals ändern!


### PR DESCRIPTION
## 🚨 KRITISCH: PRODUCTION BLOCKER

**Dies ist ein HOTFIX der SOFORT gemergt werden muss!**

## 🎯 Ziel

Wiederherstellung des Original-Checksums von Migration V243 um Flyway-Fehler in Production zu verhindern.

## ⚠️ Risiko

**OHNE diesen Fix:**
- ❌ Flyway validate schlägt in allen Umgebungen fehl, die V243 bereits deployed haben
- ❌ Neue Deployments sind blockiert
- ❌ `flyway repair` müsste manuell in jeder Umgebung ausgeführt werden

**MIT diesem Fix:**
- ✅ Checksums sind konsistent zwischen Umgebungen
- ✅ Deployments funktionieren ohne manuelle Eingriffe
- ✅ Kein funktionaler Impact (redundanter GRANT ist harmlos)

## 🔍 Problem-Analyse

In PR #107 wurde V243 nachträglich geändert (redundanter GRANT entfernt).
Das verletzt die **goldene Flyway-Regel**: Deployed migrations dürfen NIE geändert werden!

```
V243 Checksum in Prod: -1348567549 (mit GRANT)
V243 Checksum aktuell: -677543044 (ohne GRANT)
```

## ✅ Lösung

1. **V243 zurückgesetzt** auf Original-Zustand mit redundantem GRANT
2. **V244 hinzugefügt** als idempotenter Cleanup mit Dokumentation
3. Kein funktionaler Impact - PostgreSQL ignoriert doppelte GRANTs

## 🔄 Migrations-Schritte + Rollback

**Deployment:**
```bash
# 1. PR sofort mergen
# 2. Normale CI/CD Pipeline
# V244 wird automatisch angewendet (no-op)
```

**Rollback:** Nicht nötig - V244 ist idempotent

## ⚡ Performance-Nachweis

- V244 ist ein reiner DO-Block mit NOTICE
- Keine DDL/DML Operationen
- Execution time: <1ms

## 🔒 Security-Checks

- [x] Keine strukturellen Änderungen
- [x] Nur idempotente Dokumentation
- [x] Keine Secrets oder sensitive Daten

## 📚 SoT-Referenzen

- Issue: **FP-277** (aus KI-Review identifiziert)
- Original PR: #107 (wo der Fehler passierte)
- Flyway Best Practice: Never change deployed migrations

## 🧪 Test-Plan

- [x] Backend kompiliert erfolgreich
- [x] V244 Migration ist valides SQL
- [x] Lokale Checksum-Warnung erwartet (da lokale DB alte Version hat)
- [ ] CI Pipeline wird grün (nach Merge)

## ⏰ Dringlichkeit

**PRODUCTION BLOCKER** - Muss SOFORT gemergt werden bevor nächstes Deployment!

Danke an die externe KI-Review, die dieses kritische Problem identifiziert hat! 🙏